### PR TITLE
Update README with clarifications and additional information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Genkit Text-to-Speech with Gemini Models
 
-This project serves as a developer's guide and example implementation for leveraging Genkit with Google's Gemini text-to-speech models. It demonstrates how to generate high-quality, synthesized audio from text, supporting both single-speaker and multi-speaker use cases. The generated audio is provided in the WAV format.
+This project serves as a developer's guide and example implementation for leveraging [Genkit](http://www.genkit.dev) with Google's Gemini text-to-speech models. It demonstrates how to generate high-quality, synthesized audio from text, supporting both single-speaker and multi-speaker use cases. The generated audio is provided in the WAV format.
 
 This README will guide you through setting up the project, understanding its key components, and exploring the code examples for generating speech.
 
@@ -31,12 +31,13 @@ Follow these steps to get the project running locally:
     ```bash
     npm install
     ```
+    This sample is confirmed to work with Genkit version 1.8.0 (including `@genkit-ai/googleai` and `genkit-cli`).
 
 3.  **Configure Google Cloud Authentication (API Key):**
-    Genkit, using the `@genkit-ai/googleai` plugin, requires authentication to use Google Cloud services like the Gemini API for text-to-speech.
+    [Genkit](http://www.genkit.dev), using the `@genkit-ai/googleai` plugin, requires authentication to use Google Cloud services like the Gemini API for text-to-speech.
 
     *   **Recommended: Using an API Key via a `.env` file:**
-        This project is configured to use the `dotenv` package, which loads environment variables from a `.env` file in the project root. The `src/ai/dev.ts` file (the entry point for Genkit development) already includes `import { config } from 'dotenv'; config();` to load this file.
+        This project is configured to use the `dotenv` package, which loads environment variables from a `.env` file in the project root. The `src/ai/dev.ts` file (the entry point for [Genkit](http://www.genkit.dev) development) already includes `import { config } from 'dotenv'; config();` to load this file.
 
         a.  **Create a `.env` file:** In the root directory of the project, create a file named `.env`.
 
@@ -47,21 +48,14 @@ Follow these steps to get the project running locally:
             Replace `"your_actual_google_api_key_here"` with your actual API key.
             *Important Security Note:* Ensure your API key is kept confidential. The `.env` file is included in the project's `.gitignore` to prevent accidental commits of sensitive information.
 
-    *   **Alternative: Using Application Default Credentials (ADC):**
-        If you prefer, and have the Google Cloud CLI (`gcloud`) installed and configured, you can set up ADC by running:
-        ```bash
-        gcloud auth application-default login
-        ```
-        Genkit can automatically pick up these credentials if no `GOOGLE_API_KEY` is found in the environment.
-
-    *Note on API Key Permissions:* Ensure the API key or the principal account for ADC has the necessary permissions to access the Vertex AI API (specifically the "Vertex AI User" role or equivalent permissions for text-to-speech models).
+    *Note on API Key Permissions:* Ensure the API key has the necessary permissions to access the Vertex AI API (specifically the "Vertex AI User" role or equivalent permissions for text-to-speech models).
 
 ## Running the Project
 
-This project has two main parts: the Genkit AI flows and a Next.js frontend.
+This project has two main parts: the [Genkit](http://www.genkit.dev) AI flows and a Next.js frontend.
 
 **1. Running Genkit Flows:**
-The core text-to-speech logic is implemented as Genkit flows. To start the Genkit development server and make these flows available (e.g., for testing via the Genkit Developer UI or for the frontend to call):
+The core text-to-speech logic is implemented as [Genkit](http://www.genkit.dev) flows. To start the [Genkit](http://www.genkit.dev) development server and make these flows available (e.g., for testing via the [Genkit](http://www.genkit.dev) Developer UI or for the frontend to call):
 
 *   Run with automatic reloading on changes:
     ```bash
@@ -72,16 +66,16 @@ The core text-to-speech logic is implemented as Genkit flows. To start the Genki
     npm run genkit:dev
     ```
 
-Once started, Genkit typically provides a local URL (e.g., `http://localhost:4000`) where you can access the Genkit Developer UI to inspect and test your flows. These npm scripts invoke `tsx src/ai/dev.ts` (as seen in `package.json`) to start the Genkit environment.
+Once started, [Genkit](http://www.genkit.dev) typically provides a local URL (e.g., `http://localhost:4000`) where you can access the [Genkit](http://www.genkit.dev) Developer UI to inspect and test your flows. These npm scripts invoke `tsx src/ai/dev.ts` (as seen in `package.json`) to start the [Genkit](http://www.genkit.dev) environment.
 
 **2. Running the Next.js Frontend (Optional):**
-This project also includes a Next.js frontend, likely for demonstrating or interacting with the Genkit flows. To run the frontend development server:
+This project also includes a Next.js frontend, likely for demonstrating or interacting with the [Genkit](http://www.genkit.dev) flows. To run the frontend development server:
 ```bash
 npm run dev
 ```
-This will typically start the frontend on `http://localhost:9002` (as per the `dev` script in `package.json`). The frontend would then make requests to the Genkit flows.
+This will typically start the frontend on `http://localhost:9002` (as per the `dev` script in `package.json`). The frontend would then make requests to the [Genkit](http://www.genkit.dev) flows.
 
-For the purpose of understanding the Genkit text-to-speech integration, focusing on running the Genkit flows (Step 1) is key.
+For the purpose of understanding the [Genkit](http://www.genkit.dev) text-to-speech integration, focusing on running the [Genkit](http://www.genkit.dev) flows (Step 1) is key.
 
 ## Code Examples and Key Files
 
@@ -102,19 +96,19 @@ Here's where to find the core logic and examples within the project:
     *   **Output (for both functions - `TextToSpeechOutput`):**
         *   `audioDataUri: string`: A base64 encoded data URI for the generated WAV audio.
 
-*   **`src/ai/genkit.ts`**: This file initializes Genkit and configures the Google AI plugin (`@genkit-ai/googleai`). You can see how the `gemini-2.0-flash` model is set as a default (though the TTS flows specify the TTS-specific model like `gemini-2.5-flash-preview-tts`).
+*   **`src/ai/genkit.ts`**: This file initializes [Genkit](http://www.genkit.dev) and configures the Google AI plugin (`@genkit-ai/googleai`). You can see how the `gemini-2.0-flash` model is set as a default (though the TTS flows specify the TTS-specific model like `gemini-2.5-flash-preview-tts`).
 
-*   **`src/ai/dev.ts`**: This file is the entry point for running Genkit in development mode (used by `npm run genkit:dev` and `npm run genkit:watch`). It imports `dotenv` to load environment variables and also imports the flow files (like `text-to-speech.ts`) to make them available to the Genkit framework.
+*   **`src/ai/dev.ts`**: This file is the entry point for running [Genkit](http://www.genkit.dev) in development mode (used by `npm run genkit:dev` and `npm run genkit:watch`). It imports `dotenv` to load environment variables and also imports the flow files (like `text-to-speech.ts`) to make them available to the [Genkit](http://www.genkit.dev) framework.
 
-*   **`src/app/page.tsx`**: This is the main page for the Next.js frontend application. If you run the frontend, this is where UI elements would likely interact with the Genkit text-to-speech flows.
+*   **`src/app/page.tsx`**: This is the main page for the Next.js frontend application. If you run the frontend, this is where UI elements would likely interact with the [Genkit](http://www.genkit.dev) text-to-speech flows.
 
-By examining these files, particularly `text-to-speech.ts`, developers can understand how to implement and customize text-to-speech generation using Genkit and Gemini models.
+By examining these files, particularly `text-to-speech.ts`, developers can understand how to implement and customize text-to-speech generation using [Genkit](http://www.genkit.dev) and Gemini models.
 
 ## Understanding the Audio Generation Process
 
 The core of the audio generation relies on the following:
 
-*   **Gemini TTS Model:** The flows in `src/ai/flows/text-to-speech.ts` utilize one of Google's advanced text-to-speech models, specifically `gemini-2.5-flash-preview-tts` (as of the last review of the code), via the Genkit `ai.generate()` call. This model is responsible for converting the input text into audio data.
+*   **Gemini TTS Model:** The flows in `src/ai/flows/text-to-speech.ts` utilize one of Google's advanced text-to-speech models, specifically `gemini-2.5-flash-preview-tts` (as of the last review of the code), via the [Genkit](http://www.genkit.dev) `ai.generate()` call. This model is responsible for converting the input text into audio data.
 *   **Audio Format (PCM to WAV):**
     *   The Gemini TTS model initially returns audio data in PCM (Pulse Code Modulation) format, typically as a base64 encoded string within a data URI.
     *   The project includes utility functions (e.g., `pcmToWavDataUri` in `text-to-speech.ts`) that convert this raw PCM data into the more common and web-friendly WAV audio format. This involves creating a WAV file structure, including headers, around the PCM data.
@@ -122,9 +116,17 @@ The core of the audio generation relies on the following:
 
 This two-step process (generation by Gemini, then conversion to WAV) ensures that the application delivers audio in a widely usable format.
 
+## Project Status & Future Maintenance
+
+Please note: This project is a sample to demonstrate what's possible with [Genkit](http://www.genkit.dev) and Google's text-to-speech models at the time of its creation. It may not be actively maintained to address future breaking changes in dependencies or APIs unless explicitly stated otherwise.
+
 ## Further Exploration
 
 *   **Experiment with Voices:** Explore different voice names available for the Gemini TTS models.
 *   **Error Handling:** Enhance the error handling within the flows for more robust application behavior.
 *   **Frontend Integration:** Expand the Next.js frontend (`src/app/page.tsx`) to create a more interactive experience with the text-to-speech capabilities.
-*   **Other Genkit Features:** Explore other features of Genkit for building more complex AI flows.
+*   **Other Genkit Features:** Explore other features of [Genkit](http://www.genkit.dev) for building more complex AI flows.
+
+## How This Project Was Created
+
+This project was initially created using [Firebase Studio](http://firebase.studio/), which is powered by Gemini 2.5. Additional changes and refinements were made with the assistance of [Jules](https://jules.google/).


### PR DESCRIPTION
This commit addresses several points to improve the README:

1.  Removed mention of gCloud/ADC authentication as Genkit does not support it. The focus is now solely on API key authentication.
2.  Added a "How This Project Was Created" section, detailing the use of Firebase Studio (powered by Gemini 2.5) and myself, with inline links to both.
3.  Specified that the sample is confirmed to work with Genkit version 1.8.0 in the dependencies section.
4.  Added a disclaimer that the project is a sample and might not be maintained for future breaking changes.
5.  Updated mentions of "Genkit" to be inline links to the genkit.dev website for easier navigation.